### PR TITLE
Fire control clicks immediately and start looping after a short delay

### DIFF
--- a/public/script/main.js
+++ b/public/script/main.js
@@ -22,12 +22,13 @@ $(document).ready(() => {
     function controlClickSetup( element, action, direction )
     {
         var cclickInterval = ControlKeyInterval
+        var cclickIntervalDelay = ControlKeyIntervalDelay
         var cclickTimeoutHandle, cclickIntervalHandle
         let startEvents = ( e ) => {
             controlClick( action, direction, element )
             cclickTimeoutHandle = setTimeout( () => {
                 cclickIntervalHandle = setInterval( ()=>controlClick( action, direction, element ), cclickInterval )
-            }, ControlKeyIntervalDelay)
+            }, cclickIntervalDelay)
             
             highlight( $("#"+element), "20, 255, 20" )
         }

--- a/public/script/main.js
+++ b/public/script/main.js
@@ -6,6 +6,7 @@ var currentLoadedPrefabList = null;
 var prefabGroups = {};
 var nextPrefabGroupId = 1;
 var ControlKeyInterval = 100
+var ControlKeyIntervalDelay = 500
 
 $(document).ready(() => {
     $("i").each( ( ind, img ) => {
@@ -21,16 +22,22 @@ $(document).ready(() => {
     function controlClickSetup( element, action, direction )
     {
         var cclickInterval = ControlKeyInterval
-        var cclickTimeout
+        var cclickTimeoutHandle, cclickIntervalHandle
         let startEvents = ( e ) => {
-            cclickTimeout = setInterval( ()=>controlClick( action, direction, element ), cclickInterval )
+            controlClick( action, direction, element )
+            cclickTimeoutHandle = setTimeout( () => {
+                cclickIntervalHandle = setInterval( ()=>controlClick( action, direction, element ), cclickInterval )
+            }, ControlKeyIntervalDelay)
+            
             highlight( $("#"+element), "20, 255, 20" )
         }
         let endEvents = ( e ) => {
-            if ( !!cclickTimeout ) {
+            if ( !!cclickTimeoutHandle || !!cclickIntervalHandle ) {
                 flash( $("#"+element), "20, 255, 20" )
-                clearTimeout( cclickTimeout )
-                cclickTimeout = undefined
+                clearTimeout( cclickTimeoutHandle )
+                clearTimeout( cclickIntervalHandle )
+                cclickTimeoutHandle = undefined
+                cclickIntervalHandle = undefined
             }
         }
 


### PR DESCRIPTION
## Context

When clicking a control button too quickly (as in, mouse isn't held down longer than 100 ms) the click doesn't register at all. A better user experience would be that any click, no matter how long pressed down, would register at least once.

Another good user experience is to start repeating clicks (due to holding down the control button) only after a brief delay. This is so that minute change can be made with single clicks without the risk of accidentally triggering the fast loops (100ms cycles).

Closes #27 

## Changes

- Added a call site for `controlClick()` outside of the `setInterval()` body. This will trigger a call immediately when clicking a control button.
- Wrapped the `setInterval()` loop in a `setTimeout()` to delay the loop by half a second (in line with other Windows user experiences, such as holding down a key on your keyboard).